### PR TITLE
parsing /proc/[pid]/stat fails if a process name contains a space

### DIFF
--- a/lib/providers/proc/procStat/linux.js
+++ b/lib/providers/proc/procStat/linux.js
@@ -1,10 +1,10 @@
 var fs = require('fs');
 
 var STAT_INDEXES = {
-    STIME: 13,
-    UTIME: 14,
-    START_TIME: 21,
-    RSS: 23
+    STIME: 11,
+    UTIME: 12,
+    START_TIME: 19,
+    RSS: 21
 };
 
 function getLinuxProcStat(pid, callback) {
@@ -15,6 +15,7 @@ function getLinuxProcStat(pid, callback) {
         if(err) {
             callback(err);
         } else {
+            data = data.substr(data.lastIndexOf(')') + 2);
             var parts = data.split(' ');
             var statObject = {
                 stime: parseFloat(parts[STAT_INDEXES.STIME]),


### PR DESCRIPTION
``` javascript
process.title = process.argv[2] || ':-) 1 2 3 4 5 6';

require('fs').readFile('/proc/'+process.pid+'/stat', 'utf8', console.log);
require('usage').lookup(process.pid, console.log);
```

In the example above /proc/[pid]/stat starts with this: `7014 (:-) 1 2 3 4 5 6) R 5963 7014 5963 ...` and data.split(' ') parses that one incorrectly.
