### PR TITLE
Explicit cast to uv_after_work_cb added to fix compatibility issue on node v0.10 under solaris

### DIFF
--- a/src/solaris.cpp
+++ b/src/solaris.cpp
@@ -119,7 +119,7 @@ Handle<Value> GetUsage(const Arguments& args) {
     uv_work_t* req = new uv_work_t();
     req->data = usageData;
 
-    uv_queue_work(uv_default_loop(), req, AsyncGetUsage, AsyncAfterGetUsage);
+    uv_queue_work(uv_default_loop(), req, AsyncGetUsage, (uv_after_work_cb)AsyncAfterGetUsage);
     
     return scope.Close(Undefined());
 }


### PR DESCRIPTION
This is caused by an API change (signature of uv_after_work_cb changed), see migration guide on https://github.com/joyent/node/wiki/Api-changes-between-v0.8-and-v0.10.

Fixes #11
