### PR TITLE
support for FreeBSD

### DIFF
--- a/lib/providers/bsd.js
+++ b/lib/providers/bsd.js
@@ -2,10 +2,10 @@ var exec = require('child_process').exec;
 
 module.exports = function(sysinfo) {
 
-    return new MacProvider(sysinfo);
+    return new BSDProvider(sysinfo);
 };
 
-function MacProvider(sysinfo) {
+function BSDProvider(sysinfo) {
 
     this.lookup = function(pid, options, callback) {
 

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -1,7 +1,8 @@
 var providers = {
     'linux': require('./proc'),
     'solaris': require('./solaris'),
-    'mac': require('./mac'),
+    'mac': require('./bsd'),
+    'freebsd': require('./bsd'),
     'win': require('./win'),
     'other': require('./other')
 };


### PR DESCRIPTION
A very simple update to support FreeBSD.  Note that MacOS X's userland is basically pulled directly from FreeBSD (for example, on your Mac, run `strings /bin/ps | grep FreeBSD`), so I've changed the Mac provider to be named BSD and have both FreeBSD and Macs point at that.  I suspect that an equivalent change would also support NetBSD and OpenBSD, but I don't have either of them handy to test with.
