### PR TITLE
Symbol to String - fix v0.11.13

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -4,17 +4,17 @@ using namespace v8;
 
 void RegisterModule(Handle<Object> target) {
 
-#ifdef is_linux
-    target->Set(String::NewSymbol("HERTZ"), Number::New(sysconf(_SC_CLK_TCK)));
-    target->Set(String::NewSymbol("PAGE_SIZE"), Number::New(sysconf(_SC_PAGESIZE)));
-#endif
+	#ifdef is_linux
+	    target->Set(String::New("HERTZ"), Number::New(sysconf(_SC_CLK_TCK)));
+	    target->Set(String::New("PAGE_SIZE"), Number::New(sysconf(_SC_PAGESIZE)));
+	#endif
 
-#ifdef is_solaris
-    target->Set(String::NewSymbol("getUsage"), 
-        FunctionTemplate::New(GetUsage)->GetFunction());
-#endif
+	#ifdef is_solaris
+	    target->Set(String::New("getUsage"), 
+	        FunctionTemplate::New(GetUsage)->GetFunction());
+	#endif
 
-    target->Set(String::NewSymbol("OS"), String::New(OS));
+	    target->Set(String::New("OS"), String::New(OS));
 }
 
 NODE_MODULE(sysinfo, RegisterModule);

--- a/src/solaris.cpp
+++ b/src/solaris.cpp
@@ -92,8 +92,8 @@ void AsyncAfterGetUsage(uv_work_t* req) {
         usageData->callback->Call(Context::GetCurrent()->Global(), argc, argv);
     } else {
         Local<Object> usage = Object::New();
-        usage->Set(String::NewSymbol("cpu"), Number::New(usageData->ps_usage.cpu));
-        usage->Set(String::NewSymbol("memory"), Number::New(usageData->ps_usage.memory));
+        usage->Set(String::New("cpu"), Number::New(usageData->ps_usage.cpu));
+        usage->Set(String::New("memory"), Number::New(usageData->ps_usage.memory));
 
         const unsigned argc = 2;
         Local<Value> argv[argc] = { Local<Value>::New(Null()), usage };


### PR DESCRIPTION
As of V8 3.24 Symbol API has changed an NewSymbol does not exists anymore (https://code.google.com/p/v8/source/browse/branches/3.24/include/v8.h#1909)
I tried with the new API Symbol::New(isolate, 'char') with no success - btw source code is mentionning that it's an experimental feature.
Changed to String seems to do the job pretty well, is there any reason that would make that to fail?
#27
