### PR TITLE
Update nan dependency - add support for iojs/node v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "bindings": "1.x.x",
-    "nan": "1.6.x"
+    "nan": "^1.8.0"
   },
   "devDependencies": {
     "mocha": "1.x.x"


### PR DESCRIPTION
This adds support for iojs and node v0.12